### PR TITLE
Add entries function to convert a map to an array

### DIFF
--- a/builtin/builtin.go
+++ b/builtin/builtin.go
@@ -46,6 +46,7 @@ func init() {
 		"drop":       Drop,
 		"append":     Append,
 		"stdin":      Stdin,
+		"entries":    Entries,
 	})
 }
 
@@ -360,4 +361,12 @@ func Drop(item interface{}, items []interface{}) ([]interface{}, error) {
 		}
 	}
 	return out, nil
+}
+
+func Entries(pattern string, m map[interface{}]interface{}) []interface{} {
+	ret := []interface{}{}
+	for k, v := range m {
+		ret = append(ret, fmt.Sprintf(pattern, k, v))
+	}
+	return ret
 }

--- a/circle.yml
+++ b/circle.yml
@@ -4,6 +4,7 @@ machine:
 
 dependencies:
   pre:
+    - make deps
     - docker run --rm gliderlabs/glu | tar xC /home/ubuntu/bin
     - glu circleci
     - glu container up

--- a/tests/sigil.bash
+++ b/tests/sigil.bash
@@ -1,6 +1,12 @@
 GOOS=$(go env GOOS)
 export SIGIL="${SIGIL:-build/${GOOS^}/sigil}"
 
+T_entries_with_join() {
+    result=$(echo '{{ $y := yaml "tests/test.yml"}}{{ $y.images | entries "%v=%v" | join ","  }}' | $SIGIL)
+    echo "HACK=$result"
+    [[ "$result" == "us-east-1=ami-11111111,us-west-1=ami-22222222" ]]
+}
+
 T_posix_var() {
   result=$(echo 'Hello, $name' | $SIGIL -p name=Jeff)
   [[ "$result" == "Hello, Jeff" ]]

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,0 +1,3 @@
+images:
+  us-east-1: ami-11111111
+  us-west-1: ami-22222222


### PR DESCRIPTION
Entries takes its first argument as an fmt.Printf() type format string, and iterates over
the second argument, which should be a map. The resulting array is constructed by
collecting fmt.Sprintf(format, key, value) for each map entry