### PR TITLE
Add partial builtin

### DIFF
--- a/builtin/builtin.go
+++ b/builtin/builtin.go
@@ -3,6 +3,7 @@ package builtin
 import (
 	"bytes"
 	"encoding/json"
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -25,6 +26,7 @@ func init() {
 	sigil.Register(template.FuncMap{
 		// templating
 		"include": Include,
+		"partial": Partial,
 		"default": Default,
 		"var":     Var,
 		// strings
@@ -366,6 +368,17 @@ func Include(filename string, args ...interface{}) (interface{}, error) {
 	defer sigil.PopPath()
 	render, err := render(data, args, filepath.Base(path))
 	return render.String(), err
+}
+
+func Partial(filename string) (interface{}, error) {
+	var vars []interface{}
+	for _, arg := range flag.Args() {
+		parts := strings.SplitN(arg, "=", 2)
+		if len(parts) == 2 {
+			vars = append(vars, arg)
+		}
+	}
+	return Include(filename, vars...)
 }
 
 func Indent(indent string, in interface{}) (interface{}, error) {


### PR DESCRIPTION
Partials inherit the global context, allowing users to copy mostly duplicate template matter into sub-templates. As a trade-off, they do not allow overriding the context at compile-time.