### PR TITLE
Make go templating left and right delimiter customizable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,20 @@ in this form is simply used as:
 You can do much more with this syntax, such as modifier pipelines. All of which
 is explained below.
 
+#### Custom Delimiters
+
+Sometimes you want to use sigil to generate text, which uses golang templating itself.
+For example if you want to generate [packer](https://www.packer.io/docs/) configuration
+your template might contain a lot of `{{` and `}}`.
+
+Intead of replacing all `{{` with `{{“{{”}}`, you can change the delimiters,
+by setting the `SIGIL_DELIMS` environment variable. It is the left and right
+delimiter strings, separated by a coma.
+
+```
+SIGIL_DELIMS={{{,}}}  sigil -i 'hello {{{ $name }}}' name=packer
+```
+
 ### Functions
 
 There are a number of builtin functions that can be used as modifiers,

--- a/tests/sigil.bash
+++ b/tests/sigil.bash
@@ -91,3 +91,9 @@ T_httpget() {
   result="$($SIGIL -i '{{ httpget "https://httpbin.org/get" | json | pointer "/url" }}')"
 	[[ "$result" == "https://httpbin.org/get" ]]
 }
+
+T_custom_delim() {
+  result="$(SIGIL_DELIMS={{{,}}} $SIGIL -i '{{ hello {{{ $name }}} }}' name=packer)"
+	[[ "$result" == "{{ hello packer }}" ]]
+
+}


### PR DESCRIPTION
Lately i tried to generate packer.io files. But packer itself uses go templating.

So you have to replace all `{{` with `{{"{{"}}` and the same goes: `}}` to `{{"}}"}}`. It makes the template really hard tpo read. With the propose env variables sigil could use, let's say triple braces to generate files which use go templating:

I'm able to switch on a section with a variable:
```
SIGIL_LEFT_DELIM={{{ SIGIL_RIGHT_DELIM=}}} sigil -f packer.tmpl atlas=true
```
or switch off:
```
SIGIL_LEFT_DELIM={{{ SIGIL_RIGHT_DELIM=}}} sigil -f packer.tmpl atlas=true
```

content of `packer.tmpl`:
```
{
  "variables": {
    "mock": "{{ env `MOCK` }}",

    "aws_access_key": "{{ env `AWS_ACCESS_KEY` }}",
    "aws_secret_key": "{{ env `AWS_SECRET_ACCESS_KEY` }}"
  },

  {{{ with $atlas }}}
  "post-processors": [
    {
      "type": "atlas",
      "artifact": "sequenceiq/{{ user `atlas_artifact` }}",
      "artifact_type": "{{ build_name }}.image"
    }
  ]
  {{{ end }}}
}
```