### PR TITLE
Add yamltojson function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,14 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 ### Added
+- Make go templating left and right delimiter customizable.
+- Add substring function
+- Add yamltojson function
 
 ### Removed
 
 ### Changed
 
-[unreleased]: https://github.com/gliderlabs/glidergun/compare/v0.1.0...HEAD
+## [0.4.0] - 2016.02.20
+
+[unreleased]: https://github.com/gliderlabs/sigil/compare/v0.4.0...HEAD

--- a/builtin/builtin.go
+++ b/builtin/builtin.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/dustin/go-jsonpointer"
 	"github.com/flynn/go-shlex"
+	yyaml "github.com/ghodss/yaml"
 	"github.com/gliderlabs/sigil"
 	"gopkg.in/yaml.v2"
 )
@@ -49,19 +50,20 @@ func init() {
 		"sh":      Shell,
 		"httpget": HttpGet,
 		// structured data
-		"pointer": Pointer,
-		"json":    Json,
-		"tojson":  ToJson,
-		"yaml":    Yaml,
-		"toyaml":  ToYaml,
-		"uniq":    Uniq,
-		"drop":    Drop,
-		"append":  Append,
-		"seq":     Seq,
-		"join":    Join,
-		"joinkv":  JoinKv,
-		"split":   Split,
-		"splitkv": SplitKv,
+		"pointer":    Pointer,
+		"json":       Json,
+		"tojson":     ToJson,
+		"yaml":       Yaml,
+		"toyaml":     ToYaml,
+		"uniq":       Uniq,
+		"drop":       Drop,
+		"append":     Append,
+		"seq":        Seq,
+		"join":       Join,
+		"joinkv":     JoinKv,
+		"split":      Split,
+		"splitkv":    SplitKv,
+		"yamltojson": YamlToJson,
 	})
 }
 
@@ -317,6 +319,19 @@ func ToYaml(obj interface{}) (interface{}, error) {
 		return nil, err
 	}
 	return string(data), nil
+}
+
+func YamlToJson(in interface{}) (interface{}, error) {
+	in_, _, ok := sigil.String(in)
+	if !ok {
+		return nil, fmt.Errorf("ymltojson must be given a string")
+	}
+
+	j2, err := yyaml.YAMLToJSON([]byte(in_))
+	if err != nil {
+		return nil, err
+	}
+	return string(j2), nil
 }
 
 func Pointer(path string, in interface{}) (interface{}, error) {

--- a/tests/sigil.bash
+++ b/tests/sigil.bash
@@ -101,8 +101,13 @@ T_substr() {
   result="$($SIGIL -i '{{ "abcdefgh" | substr "1:4" }}')"
 	[[ "$result" == "bcd" ]]
 }
+
 T_substr_single_index() {
   result="$($SIGIL -i '{{ "abcdefgh" | substr ":4" }}')"
 	[[ "$result" == "abcd" ]]
 }
 
+T_yamltojson() {
+  result="$(printf 'joe:\n  age: 32\n  color: red' | $SIGIL -i '{{ stdin |  yamltojson }}')"
+    [[ "$result" == '{"joe":{"age":32,"color":"red"}}' ]]
+}


### PR DESCRIPTION
If i try to convert some non trivial yaml/map to json it fails with `error calling tojson: json: unsupported type: map[interface {}]interface {}`

```
$ sigil -i '{{ stdin |  yaml | tojson }}'  << EOF 
joe:
  age: 32
  colors:
  - red
  - green
EOF
```

The `yamltojson` can convert any yaml to json:

```
$ sigil -i '{{ stdin |  yamltojson }}'  << EOF 
joe:
  age: 32
  colors:
  - red
  - green
EOF

{"joe":{"age":32,"colors":["red","green"]}}
```
