### PR TITLE
mistake protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ for any text processing.
 ## Getting Sigil
 
 ```
-$ curl https://dl.gliderlabs.com/sigil/latest/$(uname -sm|tr \  _).tgz \
+$ curl http://dl.gliderlabs.com/sigil/latest/$(uname -sm|tr \  _).tgz \
     | tar -zxC /usr/local/bin
 ```
 


### PR DESCRIPTION
Right now, `https://dl.gliderlabs.com` is insecure. This warning can be avoided by HTTP access.
