### PR TITLE
Add jmespath function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 ### Added
+- Add [jmespath](http://jmespath.org) function
 
 ### Removed
 

--- a/builtin/builtin.go
+++ b/builtin/builtin.go
@@ -18,6 +18,7 @@ import (
 	"github.com/dustin/go-jsonpointer"
 	"github.com/flynn/go-shlex"
 	"github.com/gliderlabs/sigil"
+	"github.com/jmespath/go-jmespath"
 	"gopkg.in/yaml.v2"
 )
 
@@ -49,19 +50,20 @@ func init() {
 		"sh":      Shell,
 		"httpget": HttpGet,
 		// structured data
-		"pointer": Pointer,
-		"json":    Json,
-		"tojson":  ToJson,
-		"yaml":    Yaml,
-		"toyaml":  ToYaml,
-		"uniq":    Uniq,
-		"drop":    Drop,
-		"append":  Append,
-		"seq":     Seq,
-		"join":    Join,
-		"joinkv":  JoinKv,
-		"split":   Split,
-		"splitkv": SplitKv,
+		"pointer":  Pointer,
+		"json":     Json,
+		"jmespath": JmesPath,
+		"tojson":   ToJson,
+		"yaml":     Yaml,
+		"toyaml":   ToYaml,
+		"uniq":     Uniq,
+		"drop":     Drop,
+		"append":   Append,
+		"seq":      Seq,
+		"join":     Join,
+		"joinkv":   JoinKv,
+		"split":    Split,
+		"splitkv":  SplitKv,
 	})
 }
 
@@ -94,7 +96,7 @@ func HttpGet(in interface{}) (interface{}, error) {
 	if err != nil {
 		return "", err
 	}
-	return sigil.NamedReader{resp.Body, "<"+in_+">"}, nil
+	return sigil.NamedReader{resp.Body, "<" + in_ + ">"}, nil
 }
 
 func JoinKv(sep string, in interface{}) ([]interface{}, error) {
@@ -356,6 +358,20 @@ func Pointer(path string, in interface{}) (interface{}, error) {
 		return nil, fmt.Errorf("pointer needs a map type")
 	}
 	return jsonpointer.Get(m, path), nil
+}
+
+func JmesPath(path string, in interface{}) (interface{}, error) {
+	precompiled, err := jmespath.Compile(path)
+	if err != nil {
+		return nil, fmt.Errorf("JmesPath compileerror: %v", err)
+	}
+
+	result, err := precompiled.Search(in)
+	if err != nil {
+		return nil, fmt.Errorf("JmesPath search error: %v", err)
+	}
+
+	return result, nil
 }
 
 func Render(args ...interface{}) (interface{}, error) {

--- a/tests/sigil.bash
+++ b/tests/sigil.bash
@@ -134,3 +134,7 @@ EOF
     [[ "$result" == '{"a":"Easy!","b":{"c":2,"d":[3,4]},"c":{"list":["one","two","tree"]}}' ]]
 }
 
+T_jmespath() {
+  result="$(echo '[{"name":"bob","age":20},{"name":"jim","age":30},{"name":"joe","age":40}]' | $SIGIL -i '{{stdin | json | jmespath "[? age >= `30`].name | reverse(@)"  | join ","}}')"
+    [[ "$result" == 'joe,jim' ]]
+}


### PR DESCRIPTION
While working a lot with aws cli, i realized that most of the json gymnastic i did recently with jq.

I know that Matt started to work on a jq golang integration it:https://github.com/mattaitchison/jq
but its much easier to integrate jmespath. 