### PR TITLE
Fix tojson 2

### DIFF
--- a/builtin/builtin.go
+++ b/builtin/builtin.go
@@ -289,8 +289,31 @@ func Json(file interface{}) (interface{}, error) {
 	return obj, nil
 }
 
+func convert(v interface{}) interface{} {
+	switch t := v.(type) {
+	case map[interface{}]interface{}:
+		return convertMap(t)
+	}
+	return v
+}
+
+func convertMap(m map[interface{}]interface{}) map[string]interface{} {
+	m2 := make(map[string]interface{})
+	for k, v := range m {
+		switch key := k.(type) {
+		case string:
+			m2[key] = convert(v)
+
+		default:
+			s := k.(string)
+			m2[s] = convert(v)
+		}
+	}
+	return m2
+}
+
 func ToJson(obj interface{}) (interface{}, error) {
-	data, err := json.Marshal(obj)
+	data, err := json.Marshal(convert(obj))
 	if err != nil {
 		return nil, err
 	}

--- a/tests/sigil.bash
+++ b/tests/sigil.bash
@@ -76,6 +76,11 @@ T_json() {
 	[[ "$result" == "{\"one\":\"two\"}" ]]
 }
 
+T_json_deep() {
+	result=$(echo '{"foo": {"one": "two"}}' | $SIGIL -i '{{ stdin | json | tojson }}')
+	[[ "$result" == '{"foo":{"one":"two"}}' ]]
+}
+
 T_yaml() {
 	yaml="$(echo -e "one: two\nthree:\n- four\n- five")"
 	result="$(echo -e "$yaml" | $SIGIL -i '{{ stdin | yaml | toyaml }}')"
@@ -104,5 +109,28 @@ T_substr() {
 T_substr_single_index() {
   result="$($SIGIL -i '{{ "abcdefgh" | substr ":4" }}')"
 	[[ "$result" == "abcd" ]]
+}
+
+T_yamltojson() {
+  result="$(printf 'joe:\n  age: 32\n  color: red' | $SIGIL -i '{{ stdin |  yaml | tojson }}')"
+    [[ "$result" == '{"joe":{"age":32,"color":"red"}}' ]]
+}
+
+T_yamltojsondeep() {
+    result="$( $SIGIL -i '{{ stdin |  yaml | tojson }}' <<EOF
+a: Easy!
+b:
+  c: 2
+  d:
+  - 3
+  - 4
+c:
+  list:
+  - one
+  - two
+  - tree
+EOF
+)"
+    [[ "$result" == '{"a":"Easy!","b":{"c":2,"d":[3,4]},"c":{"list":["one","two","tree"]}}' ]]
 }
 

--- a/tests/sigil.bash
+++ b/tests/sigil.bash
@@ -67,8 +67,8 @@ T_split_join() {
 }
 
 T_splitkv_joinkv() {
-  result=$(echo 'one:two,three:four' | $SIGIL -i '{{ stdin | split "," | splitkv ":" | joinkv "=" | join "," }}')
-  [[ "$result" == "one=two,three=four" ]]
+  result=$(echo -n 'one:two,three:four' | $SIGIL -i '{{ stdin | split "," | splitkv ":" | joinkv "=" | join "," }}')
+  [[ "$result" == "one=two,three=four" || "$result" == "three=four,one=two" ]]
 }
 
 T_json() {


### PR DESCRIPTION
take2 

deep maps can't be converted to json:
```
executing "<inline>" at <tojson>: error calling tojson: json: unsupported type: map[interface {}]interface {}
```

Fixes: #18 
Fixes: #29