### PR TITLE
docs: fix sigil installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ for any text processing.
 
 ## Getting Sigil
 
-```
-$ curl http://dl.gliderlabs.com/sigil/latest/$(uname -sm|tr \  _).tgz \
+```shell
+curl "https://github.com/gliderlabs/sigil/releases/download/v0.4.0/sigil_0.4.0_$(uname -sm|tr \  _).tgz" \
     | tar -zxC /usr/local/bin
 ```
 


### PR DESCRIPTION
Closes #38

[ci skip]