### PR TITLE
`exists` function never returns false on full path

### DIFF
--- a/sigil.go
+++ b/sigil.go
@@ -70,17 +70,27 @@ func PopPath() {
 
 func LookPath(file string) (string, error) {
 	if strings.HasPrefix(file, "/") {
-		return file, nil
-	}
-	cwd, _ := os.Getwd()
-	search := append([]string{cwd}, TemplatePath...)
-	for _, path := range search {
-		filepath := filepath.Join(path, file)
-		if _, err := os.Stat(filepath); err == nil {
-			return filepath, nil
+		if fileExists(file) {
+			return file, nil
+		}
+	} else {
+		cwd, _ := os.Getwd()
+		search := append([]string{cwd}, TemplatePath...)
+		for _, path := range search {
+			filepath := filepath.Join(path, file)
+			if fileExists(filepath) {
+				return filepath, nil
+			}
 		}
 	}
 	return "", fmt.Errorf("Not found in path: %s %v", file, TemplatePath)
+}
+
+func fileExists(path string) bool {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return false
+	}
+	return true
 }
 
 func restoreEnv(env []string) {

--- a/sigil_test.go
+++ b/sigil_test.go
@@ -1,0 +1,51 @@
+package sigil
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLookPath(t *testing.T) {
+	for _, tmpDir := range []string{"", "."} {
+		for _, relative := range []bool{true, false} {
+			for _, exists := range []bool{true, false} {
+				// setup
+				f, err := ioutil.TempFile(tmpDir, "sigiltest")
+				if err != nil {
+					t.Error("failed to crate temporary file")
+					continue
+				}
+				relpath := f.Name()
+				fullpath, err := filepath.Abs(f.Name())
+				if err != nil {
+					t.Error("failed to get the absolute path")
+				}
+				if !exists {
+					os.Remove(f.Name())
+				}
+				path := fullpath
+				if relative {
+					path = relpath
+				}
+
+				// test
+				p, err := LookPath(path)
+				if exists {
+					if p != fullpath {
+						t.Errorf("expected %s but %s; tmpDir=%s, relative=%v, exists=%v", fullpath, p, tmpDir, relative, exists)
+					}
+				} else {
+					if err == nil {
+						t.Errorf("expected error. tmpDir=%s, relative=%v, exists=%v", tmpDir, relative, exists)
+					}
+				}
+
+				// teardown
+				f.Close()
+				os.Remove(f.Name())
+			}
+		}
+	}
+}

--- a/tests/sigil.bash
+++ b/tests/sigil.bash
@@ -51,9 +51,24 @@ T_capitalize() {
   [[ "$result" == "hello Jeff" ]]
 }
 
-T_exists() {
+T_exists_exist_relative() {
   result=$(echo '{{exists "Makefile"}}' | $SIGIL)
   [[ "$result" == "true" ]]
+}
+
+T_exists_exist_full() {
+  result=$(echo "{{exists \"$(pwd)/Makefile\"}}" | $SIGIL)
+  [[ "$result" == "true" ]]
+}
+
+T_exists_notexist_relative() {
+  result=$(echo '{{exists "FileNotExist"}}' | $SIGIL)
+  [[ "$result" == "false" ]]
+}
+
+T_exists_notexist_full() {
+  result=$(echo "{{exists \"$(pwd)/FileNotExist\"}}" | $SIGIL)
+  [[ "$result" == "false" ]]
 }
 
 T_XXX() {


### PR DESCRIPTION
[exists function](https://github.com/gliderlabs/sigil/blob/master/builtin/builtin.go#L482) doesn't return `false` when the path starts with "/".

Test case:

```
  result=$(echo "{{exists \"$(pwd)/FileNotExist\"}}" | $SIGIL)
  [[ "$result" == "false" ]]
```

This `$result` should be `false` because there isn't the file named "FileNotExist" in the current directory.
But currently returns `true`.