### PR TITLE
chore: remove armhf build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,10 +49,8 @@ build: prebuild
 	@$(MAKE) build/darwin/$(NAME)
 	@$(MAKE) build/linux/$(NAME)-amd64
 	@$(MAKE) build/linux/$(NAME)-arm64
-	@$(MAKE) build/linux/$(NAME)-armhf
 	@$(MAKE) build/deb/$(NAME)_$(VERSION)_amd64.deb
 	@$(MAKE) build/deb/$(NAME)_$(VERSION)_arm64.deb
-	@$(MAKE) build/deb/$(NAME)_$(VERSION)_armhf.deb
 
 build-docker-image:
 	docker build --rm -q -f Dockerfile.build -t $(IMAGE_NAME):build .
@@ -85,11 +83,6 @@ build/linux/$(NAME)-arm64:
 	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -a -asmflags=-trimpath=/src -gcflags=-trimpath=/src \
 										-ldflags "-s -w -X main.Version=$(VERSION)" \
 										-o build/linux/$(NAME)-arm64 cmd/sigil.go
-build/linux/$(NAME)-armhf:
-	mkdir -p build/linux
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=5 go build -a -asmflags=-trimpath=/src -gcflags=-trimpath=/src \
-										-ldflags "-s -w -X main.Version=$(VERSION)" \
-										-o build/linux/$(NAME)-armhf cmd/sigil.go
 
 build/deb/$(NAME)_$(VERSION)_amd64.deb: build/linux/$(NAME)-amd64
 	export SOURCE_DATE_EPOCH=$(shell git log -1 --format=%ct) \
@@ -131,26 +124,6 @@ build/deb/$(NAME)_$(VERSION)_arm64.deb: build/linux/$(NAME)-arm64
 		build/linux/$(NAME)-arm64=/usr/bin/$(BINARY_NAME) \
 		LICENSE=/usr/share/doc/$(NAME)/copyright
 
-build/deb/$(NAME)_$(VERSION)_armhf.deb: build/linux/$(NAME)-armhf
-	export SOURCE_DATE_EPOCH=$(shell git log -1 --format=%ct) \
-		&& mkdir -p build/deb \
-		&& fpm \
-		--architecture armhf \
-		--category utils \
-		--description "$$PACKAGE_DESCRIPTION" \
-		--input-type dir \
-		--license 'MIT License' \
-		--maintainer "$(MAINTAINER_NAME) <$(EMAIL)>" \
-		--name $(NAME) \
-		--output-type deb \
-		--package build/deb/$(NAME)_$(VERSION)_armhf.deb \
-		--url "https://github.com/$(MAINTAINER)/$(REPOSITORY)" \
-		--vendor "" \
-		--version $(VERSION) \
-		--verbose \
-		build/linux/$(NAME)-armhf=/usr/bin/$(BINARY_NAME) \
-		LICENSE=/usr/share/doc/$(NAME)/copyright
-
 clean:
 	rm -rf build release validation
 
@@ -171,17 +144,15 @@ release: build bin/gh-release
 	rm -rf release && mkdir release
 	tar -zcf release/$(NAME)_$(VERSION)_linux_amd64.tgz -C build/linux $(NAME)-amd64
 	tar -zcf release/$(NAME)_$(VERSION)_linux_arm64.tgz -C build/linux $(NAME)-arm64
-	tar -zcf release/$(NAME)_$(VERSION)_linux_armhf.tgz -C build/linux $(NAME)-armhf
 	tar -zcf release/$(NAME)_$(VERSION)_darwin_$(HARDWARE).tgz -C build/darwin $(NAME)
 	cp build/deb/$(NAME)_$(VERSION)_amd64.deb release/$(NAME)_$(VERSION)_amd64.deb
 	cp build/deb/$(NAME)_$(VERSION)_arm64.deb release/$(NAME)_$(VERSION)_arm64.deb
-	cp build/deb/$(NAME)_$(VERSION)_armhf.deb release/$(NAME)_$(VERSION)_armhf.deb
 	bin/gh-release create $(MAINTAINER)/$(REPOSITORY) $(VERSION) $(shell git rev-parse --abbrev-ref HEAD)
 
 release-packagecloud:
 	@$(MAKE) release-packagecloud-deb
 
-release-packagecloud-deb: build/deb/$(NAME)_$(VERSION)_amd64.deb build/deb/$(NAME)_$(VERSION)_arm64.deb build/deb/$(NAME)_$(VERSION)_armhf.deb
+release-packagecloud-deb: build/deb/$(NAME)_$(VERSION)_amd64.deb build/deb/$(NAME)_$(VERSION)_arm64.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/ubuntu/bionic  build/deb/$(NAME)_$(VERSION)_amd64.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/ubuntu/focal   build/deb/$(NAME)_$(VERSION)_amd64.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/ubuntu/jammy   build/deb/$(NAME)_$(VERSION)_amd64.deb
@@ -193,28 +164,19 @@ release-packagecloud-deb: build/deb/$(NAME)_$(VERSION)_amd64.deb build/deb/$(NAM
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/ubuntu/jammy    build/deb/$(NAME)_$(VERSION)_arm64.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/debian/bullseye build/deb/$(NAME)_$(VERSION)_arm64.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/debian/bookworm build/deb/$(NAME)_$(VERSION)_arm64.deb
-	package_cloud push $(PACKAGECLOUD_REPOSITORY)/ubuntu/focal    build/deb/$(NAME)_$(VERSION)_armhf.deb
-	package_cloud push $(PACKAGECLOUD_REPOSITORY)/ubuntu/jammy    build/deb/$(NAME)_$(VERSION)_armhf.deb
-	package_cloud push $(PACKAGECLOUD_REPOSITORY)/raspbian/buster build/deb/$(NAME)_$(VERSION)_armhf.deb
-	package_cloud push $(PACKAGECLOUD_REPOSITORY)/raspbian/bullseye build/deb/$(NAME)_$(VERSION)_armhf.deb
 
 validate:
 	mkdir -p validation
 	lintian build/deb/$(NAME)_$(VERSION)_amd64.deb || true
 	lintian build/deb/$(NAME)_$(VERSION)_arm64.deb || true
-	lintian build/deb/$(NAME)_$(VERSION)_armhf.deb || true
 	dpkg-deb --info build/deb/$(NAME)_$(VERSION)_amd64.deb
 	dpkg-deb --info build/deb/$(NAME)_$(VERSION)_arm64.deb
-	dpkg-deb --info build/deb/$(NAME)_$(VERSION)_armhf.deb
 	dpkg -c build/deb/$(NAME)_$(VERSION)_amd64.deb
 	dpkg -c build/deb/$(NAME)_$(VERSION)_arm64.deb
-	dpkg -c build/deb/$(NAME)_$(VERSION)_armhf.deb
 	cd validation && ar -x ../build/deb/$(NAME)_$(VERSION)_amd64.deb
 	cd validation && ar -x ../build/deb/$(NAME)_$(VERSION)_arm64.deb
-	cd validation && ar -x ../build/deb/$(NAME)_$(VERSION)_armhf.deb
 	sha1sum build/deb/$(NAME)_$(VERSION)_amd64.deb
 	sha1sum build/deb/$(NAME)_$(VERSION)_arm64.deb
-	sha1sum build/deb/$(NAME)_$(VERSION)_armhf.deb
 	go install github.com/progrium/basht/...@latest
 	basht tests/*.bash
 


### PR DESCRIPTION
The dokku project no longer supports armhf. While this project should continue to work on that system, we will no longer distribute binaries.