### PR TITLE
chore: update method of installing gems in build env and drop rpm support

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,13 +1,14 @@
-FROM golang:1.20.5-buster
+FROM golang:1.22.3-bookworm
 
+# hadolint ignore=DL3027
 RUN apt-get update \
-  && apt install apt-transport-https build-essential curl gnupg2 jq lintian rpm rsync rubygems-integration ruby-dev ruby -qy \
+  && apt install apt-transport-https build-essential curl gnupg2 jq lintian rsync rubygems-integration ruby-dev ruby -qy \
   && git clone https://github.com/bats-core/bats-core.git /tmp/bats-core \
-  && cd /tmp/bats-core \
-  && ./install.sh /usr/local \
+  && /tmp/bats-core/install.sh /usr/local \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
+# hadolint ignore=DL3028
 RUN gem install --quiet rake fpm package_cloud
 
 WORKDIR /src

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,13 +1,13 @@
 FROM golang:1.20.5-buster
 
 RUN apt-get update \
-    && apt install apt-transport-https build-essential curl gnupg2 jq lintian rpm rsync rubygems-integration ruby-dev ruby -qy \
-    && git clone https://github.com/bats-core/bats-core.git /tmp/bats-core \
-    && cd /tmp/bats-core \
-    && ./install.sh /usr/local \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+  && apt install apt-transport-https build-essential curl gnupg2 jq lintian rpm rsync rubygems-integration ruby-dev ruby -qy \
+  && git clone https://github.com/bats-core/bats-core.git /tmp/bats-core \
+  && cd /tmp/bats-core \
+  && ./install.sh /usr/local \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
-RUN gem install --no-ri --no-rdoc --quiet rake fpm package_cloud
+RUN gem install --quiet rake fpm package_cloud
 
 WORKDIR /src

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,6 @@ build: prebuild
 	@$(MAKE) build/deb/$(NAME)_$(VERSION)_amd64.deb
 	@$(MAKE) build/deb/$(NAME)_$(VERSION)_arm64.deb
 	@$(MAKE) build/deb/$(NAME)_$(VERSION)_armhf.deb
-	@$(MAKE) build/rpm/$(NAME)-$(VERSION)-1.x86_64.rpm
 
 build-docker-image:
 	docker build --rm -q -f Dockerfile.build -t $(IMAGE_NAME):build .
@@ -152,27 +151,6 @@ build/deb/$(NAME)_$(VERSION)_armhf.deb: build/linux/$(NAME)-armhf
 		build/linux/$(NAME)-armhf=/usr/bin/$(BINARY_NAME) \
 		LICENSE=/usr/share/doc/$(NAME)/copyright
 
-build/rpm/$(NAME)-$(VERSION)-1.x86_64.rpm: build/linux/$(NAME)-amd64
-	export SOURCE_DATE_EPOCH=$(shell git log -1 --format=%ct) \
-		&& mkdir -p build/rpm \
-		&& fpm \
-		--architecture x86_64 \
-		--category utils \
-		--description "$$PACKAGE_DESCRIPTION" \
-		--input-type dir \
-		--license 'MIT License' \
-		--maintainer "$(MAINTAINER_NAME) <$(EMAIL)>" \
-		--name $(NAME) \
-		--output-type rpm \
-		--package build/rpm/$(NAME)-$(VERSION)-1.x86_64.rpm \
-		--rpm-os linux \
-		--url "https://github.com/$(MAINTAINER)/$(REPOSITORY)" \
-		--vendor "" \
-		--version $(VERSION) \
-		--verbose \
-		build/linux/$(NAME)-amd64=/usr/bin/$(BINARY_NAME) \
-		LICENSE=/usr/share/doc/$(NAME)/copyright
-
 clean:
 	rm -rf build release validation
 
@@ -198,12 +176,10 @@ release: build bin/gh-release
 	cp build/deb/$(NAME)_$(VERSION)_amd64.deb release/$(NAME)_$(VERSION)_amd64.deb
 	cp build/deb/$(NAME)_$(VERSION)_arm64.deb release/$(NAME)_$(VERSION)_arm64.deb
 	cp build/deb/$(NAME)_$(VERSION)_armhf.deb release/$(NAME)_$(VERSION)_armhf.deb
-	cp build/rpm/$(NAME)-$(VERSION)-1.x86_64.rpm release/$(NAME)-$(VERSION)-1.x86_64.rpm
 	bin/gh-release create $(MAINTAINER)/$(REPOSITORY) $(VERSION) $(shell git rev-parse --abbrev-ref HEAD)
 
 release-packagecloud:
 	@$(MAKE) release-packagecloud-deb
-	@$(MAKE) release-packagecloud-rpm
 
 release-packagecloud-deb: build/deb/$(NAME)_$(VERSION)_amd64.deb build/deb/$(NAME)_$(VERSION)_arm64.deb build/deb/$(NAME)_$(VERSION)_armhf.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/ubuntu/bionic  build/deb/$(NAME)_$(VERSION)_amd64.deb
@@ -222,9 +198,6 @@ release-packagecloud-deb: build/deb/$(NAME)_$(VERSION)_amd64.deb build/deb/$(NAM
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/raspbian/buster build/deb/$(NAME)_$(VERSION)_armhf.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/raspbian/bullseye build/deb/$(NAME)_$(VERSION)_armhf.deb
 
-release-packagecloud-rpm: build/rpm/$(NAME)-$(VERSION)-1.x86_64.rpm
-	package_cloud push $(PACKAGECLOUD_REPOSITORY)/el/7           build/rpm/$(NAME)-$(VERSION)-1.x86_64.rpm
-
 validate:
 	mkdir -p validation
 	lintian build/deb/$(NAME)_$(VERSION)_amd64.deb || true
@@ -239,12 +212,9 @@ validate:
 	cd validation && ar -x ../build/deb/$(NAME)_$(VERSION)_amd64.deb
 	cd validation && ar -x ../build/deb/$(NAME)_$(VERSION)_arm64.deb
 	cd validation && ar -x ../build/deb/$(NAME)_$(VERSION)_armhf.deb
-	cd validation && rpm2cpio ../build/rpm/$(NAME)-$(VERSION)-1.x86_64.rpm > $(NAME)-$(VERSION)-1.x86_64.cpio
-	ls -lah build/deb build/rpm validation
 	sha1sum build/deb/$(NAME)_$(VERSION)_amd64.deb
 	sha1sum build/deb/$(NAME)_$(VERSION)_arm64.deb
 	sha1sum build/deb/$(NAME)_$(VERSION)_armhf.deb
-	sha1sum build/rpm/$(NAME)-$(VERSION)-1.x86_64.rpm
 	go install github.com/progrium/basht/...@latest
 	basht tests/*.bash
 


### PR DESCRIPTION
New ruby no longer supports no-ri and no-rdoc.