### PR TITLE
tests: update env to ubuntu-22.04 and cleanup workflow file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,41 +4,39 @@ name: CI
 on:
   pull_request:
     branches:
-      - '*'
+      - "*"
   push:
     branches:
-      - 'master'
-      - 'release'
+      - "main"
+      - "release"
 
 jobs:
   build:
     name: build
-    runs-on: ubuntu-20.04
-    strategy:
-      fail-fast: true
+    runs-on: ubuntu-22.04
     env:
       GITHUB_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
       PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
 
     steps:
-    - uses: actions/checkout@v2
-    - name: make version
-      run: |
-        make version .env.docker
-    - run: make ci-report
-    - run: make build-docker-image
-    - run: make build-in-docker
-    - run: make validate-in-docker
-    - name: upload packages
-      uses: actions/upload-artifact@v2
-      with:
-        name: build
-        path: build/**/*
-    - name: make release-in-docker
-      run: |
-        if [[ "${GITHUB_REF#refs/heads/}" == "release" ]]; then
-          export CI_BRANCH=${GITHUB_REF#refs/heads/}
-          export PACKAGECLOUD_REPOSITORY=dokku/dokku
-          rm .env.docker
-          make .env.docker release-in-docker release-packagecloud-in-docker
-        fi
+      - uses: actions/checkout@v2
+      - name: make version
+        run: |
+          make version .env.docker
+      - run: make ci-report
+      - run: make build-docker-image
+      - run: make build-in-docker
+      - run: make validate-in-docker
+      - name: upload packages
+        uses: actions/upload-artifact@v2
+        with:
+          name: build
+          path: build/**/*
+      - name: make release-in-docker
+        run: |
+          if [[ "${GITHUB_REF#refs/heads/}" == "release" ]]; then
+            export CI_BRANCH=${GITHUB_REF#refs/heads/}
+            export PACKAGECLOUD_REPOSITORY=dokku/dokku
+            rm .env.docker
+            make .env.docker release-in-docker release-packagecloud-in-docker
+          fi


### PR DESCRIPTION
With the move to the main branch, we need to now run ci on main instead of master.