### PR TITLE
feat: add --in-place flag for in-file template substitution

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,22 @@ delimiter strings, separated by a coma.
 SIGIL_DELIMS={{{,}}}  sigil -i 'hello {{{ $name }}}' name=packer
 ```
 
+### In-place editing
+
+Use the `--in-place` flag with `-f` to write the rendered output back to the
+template file, similar to `sed -i`:
+
+```shell
+sigil --in-place -f config.tmpl var1=foo var2=bar
+```
+
+This safely replaces the file using an atomic write (temp file + rename), so the
+original file is preserved if template processing fails. File permissions are
+retained.
+
+Note: `--in-place` requires the `-f` flag. It cannot be used with `-i` (inline)
+or stdin input.
+
 ### Functions
 
 There are a number of builtin functions that can be used as modifiers,

--- a/cmd/sigil.go
+++ b/cmd/sigil.go
@@ -17,6 +17,7 @@ var Version string
 var (
 	filename = flag.StringP("filename", "f", "", "use template file instead of STDIN")
 	inline   = flag.StringP("inline", "i", "", "use inline template string instead of STDIN")
+	inPlace  = flag.Bool("in-place", false, "write output back to the file specified by -f")
 	posix    = flag.BoolP("posix", "p", false, "preprocess with POSIX variable expansion")
 	version  = flag.BoolP("version", "v", false, "prints version")
 )
@@ -40,11 +41,47 @@ func template() ([]byte, string, error) {
 	return data, "<stdin>", nil
 }
 
+func writeInPlace(filename string, data []byte, mode os.FileMode) error {
+	dir := filepath.Dir(filename)
+	tmp, err := os.CreateTemp(dir, ".sigil-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temp file: %w", err)
+	}
+	tmpName := tmp.Name()
+
+	success := false
+	defer func() {
+		if !success {
+			os.Remove(tmpName)
+		}
+	}()
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return fmt.Errorf("failed to write temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("failed to close temp file: %w", err)
+	}
+	if err := os.Chmod(tmpName, mode); err != nil {
+		return fmt.Errorf("failed to set file permissions: %w", err)
+	}
+	if err := os.Rename(tmpName, filename); err != nil {
+		return fmt.Errorf("failed to replace file: %w", err)
+	}
+	success = true
+	return nil
+}
+
 func main() {
 	flag.Parse()
 	if *version {
 		fmt.Println(Version)
 		os.Exit(0)
+	}
+	if *inPlace && *filename == "" {
+		fmt.Fprintln(os.Stderr, "--in-place requires -f/--filename")
+		os.Exit(1)
 	}
 	if *posix {
 		sigil.PosixPreprocess = true
@@ -52,6 +89,17 @@ func main() {
 	if os.Getenv("SIGIL_PATH") != "" {
 		sigil.TemplatePath = strings.Split(os.Getenv("SIGIL_PATH"), ":")
 	}
+
+	var originalMode os.FileMode
+	if *inPlace {
+		info, err := os.Stat(*filename)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		originalMode = info.Mode()
+	}
+
 	vars := make(map[string]interface{})
 	for _, arg := range flag.Args() {
 		parts := strings.SplitN(arg, "=", 2)
@@ -69,5 +117,13 @@ func main() {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
-	os.Stdout.Write(render.Bytes())
+
+	if *inPlace {
+		if err := writeInPlace(*filename, render.Bytes(), originalMode); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	} else {
+		os.Stdout.Write(render.Bytes())
+	}
 }

--- a/tests/sigil.bash
+++ b/tests/sigil.bash
@@ -165,3 +165,60 @@ T_base64dec() {
   result="$(echo 'aGFwcHliaXJ0aGRheQo=' | $SIGIL -i '{{ stdin | base64dec }}')"
   [[ "$result" == "happybirthday" ]]
 }
+
+T_inplace_basic() {
+  tmpfile=$(mktemp)
+  echo 'Hello, {{ $name }}' > "$tmpfile"
+  $SIGIL --in-place -f "$tmpfile" name=Jeff
+  result=$(cat "$tmpfile")
+  rm -f "$tmpfile"
+  [[ "$result" == "Hello, Jeff" ]]
+}
+
+T_inplace_permissions() {
+  tmpfile=$(mktemp)
+  echo 'Hello, {{ $name }}' > "$tmpfile"
+  chmod 0755 "$tmpfile"
+  $SIGIL --in-place -f "$tmpfile" name=Jeff
+  perms=$(stat -c %a "$tmpfile" 2>/dev/null || stat -f %Lp "$tmpfile")
+  rm -f "$tmpfile"
+  [[ "$perms" == "755" ]]
+}
+
+T_inplace_posix() {
+  tmpfile=$(mktemp)
+  echo 'Hello, $name' > "$tmpfile"
+  $SIGIL --in-place -p -f "$tmpfile" name=Jeff
+  result=$(cat "$tmpfile")
+  rm -f "$tmpfile"
+  [[ "$result" == "Hello, Jeff" ]]
+}
+
+T_inplace_requires_filename() {
+  $SIGIL --in-place -i 'Hello' 2>/dev/null
+  [[ $? -ne 0 ]]
+}
+
+T_inplace_rejects_stdin() {
+  echo 'Hello' | $SIGIL --in-place 2>/dev/null
+  [[ $? -ne 0 ]]
+}
+
+T_inplace_error_preserves_file() {
+  tmpfile=$(mktemp)
+  echo 'Hello, {{ $name }' > "$tmpfile"
+  original=$(cat "$tmpfile")
+  $SIGIL --in-place -f "$tmpfile" name=Jeff 2>/dev/null
+  result=$(cat "$tmpfile")
+  rm -f "$tmpfile"
+  [[ "$result" == "$original" ]]
+}
+
+T_inplace_long_flag() {
+  tmpfile=$(mktemp)
+  echo 'Hello, {{ $name }}' > "$tmpfile"
+  $SIGIL --in-place --filename "$tmpfile" name=World
+  result=$(cat "$tmpfile")
+  rm -f "$tmpfile"
+  [[ "$result" == "Hello, World" ]]
+}

--- a/tests/sigil.bash
+++ b/tests/sigil.bash
@@ -168,7 +168,7 @@ T_base64dec() {
 
 T_inplace_basic() {
   tmpfile=$(mktemp)
-  echo 'Hello, {{ $name }}' > "$tmpfile"
+  echo 'Hello, {{ $name }}' >"$tmpfile"
   $SIGIL --in-place -f "$tmpfile" name=Jeff
   result=$(cat "$tmpfile")
   rm -f "$tmpfile"
@@ -177,7 +177,7 @@ T_inplace_basic() {
 
 T_inplace_permissions() {
   tmpfile=$(mktemp)
-  echo 'Hello, {{ $name }}' > "$tmpfile"
+  echo 'Hello, {{ $name }}' >"$tmpfile"
   chmod 0755 "$tmpfile"
   $SIGIL --in-place -f "$tmpfile" name=Jeff
   perms=$(stat -c %a "$tmpfile" 2>/dev/null || stat -f %Lp "$tmpfile")
@@ -187,7 +187,7 @@ T_inplace_permissions() {
 
 T_inplace_posix() {
   tmpfile=$(mktemp)
-  echo 'Hello, $name' > "$tmpfile"
+  echo 'Hello, $name' >"$tmpfile"
   $SIGIL --in-place -p -f "$tmpfile" name=Jeff
   result=$(cat "$tmpfile")
   rm -f "$tmpfile"
@@ -206,7 +206,7 @@ T_inplace_rejects_stdin() {
 
 T_inplace_error_preserves_file() {
   tmpfile=$(mktemp)
-  echo 'Hello, {{ $name }' > "$tmpfile"
+  echo 'Hello, {{ $name }' >"$tmpfile"
   original=$(cat "$tmpfile")
   $SIGIL --in-place -f "$tmpfile" name=Jeff 2>/dev/null
   result=$(cat "$tmpfile")
@@ -216,7 +216,7 @@ T_inplace_error_preserves_file() {
 
 T_inplace_long_flag() {
   tmpfile=$(mktemp)
-  echo 'Hello, {{ $name }}' > "$tmpfile"
+  echo 'Hello, {{ $name }}' >"$tmpfile"
   $SIGIL --in-place --filename "$tmpfile" name=World
   result=$(cat "$tmpfile")
   rm -f "$tmpfile"


### PR DESCRIPTION
## Summary

- Adds a `--in-place` long-only flag that writes rendered output back to the source file when used with `-f`/`--filename`, similar to `sed -i`
- Uses atomic writes (temp file + rename in the same directory) to preserve the original file on template errors
- Retains original file permissions after substitution

Closes #22