### PR TITLE
feat: add --vars-file flag to load variables from files

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,36 @@ The file format is auto-detected by extension:
 * `.yaml` / `.yml` - parsed as a YAML mapping
 * `.env` or any other extension - parsed as key=value lines
 
+#### JSON example (`vars.json`)
+
+```json
+{
+  "name": "Jeff",
+  "greeting": "Hello",
+  "port": 8080
+}
+```
+
+#### YAML example (`vars.yaml`)
+
+```yaml
+name: Jeff
+greeting: Hello
+port: 8080
+```
+
+#### Env example (`vars.env`)
+
+```shell
+# Database config
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME="my_database"
+export APP_ENV='production'
+```
+
+#### Usage
+
 ```shell
 # JSON vars file
 sigil -f config.tmpl -V vars.json
@@ -116,13 +146,6 @@ sigil -f config.tmpl -V defaults.yaml -V overrides.json
 # CLI args override file vars
 sigil -f config.tmpl -V vars.json name=override
 ```
-
-The env-style format supports:
-
-* Comments starting with `#`
-* Empty lines (ignored)
-* Optional `export` prefix (e.g., `export KEY=value`)
-* Optional surrounding quotes on values (single or double)
 
 ### Functions
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,43 @@ retained.
 Note: `--in-place` requires the `-f` flag. It cannot be used with `-i` (inline)
 or stdin input.
 
+### Variables from files
+
+Use the `--vars-file` (or `-V`) flag to load variables from a file instead of
+passing them all as command-line arguments. The flag can be specified multiple
+times; files are merged in order, and CLI `key=value` arguments override any
+file-sourced variables.
+
+The file format is auto-detected by extension:
+
+* `.json` - parsed as a JSON object
+* `.yaml` / `.yml` - parsed as a YAML mapping
+* `.env` or any other extension - parsed as key=value lines
+
+```shell
+# JSON vars file
+sigil -f config.tmpl -V vars.json
+
+# YAML vars file
+sigil -f config.tmpl -V vars.yaml
+
+# env-style vars file
+sigil -f config.tmpl -V vars.env
+
+# Multiple files, later overrides earlier
+sigil -f config.tmpl -V defaults.yaml -V overrides.json
+
+# CLI args override file vars
+sigil -f config.tmpl -V vars.json name=override
+```
+
+The env-style format supports:
+
+* Comments starting with `#`
+* Empty lines (ignored)
+* Optional `export` prefix (e.g., `export KEY=value`)
+* Optional surrounding quotes on values (single or double)
+
 ### Functions
 
 There are a number of builtin functions that can be used as modifiers,

--- a/cmd/sigil.go
+++ b/cmd/sigil.go
@@ -15,11 +15,12 @@ import (
 var Version string
 
 var (
-	filename = flag.StringP("filename", "f", "", "use template file instead of STDIN")
-	inline   = flag.StringP("inline", "i", "", "use inline template string instead of STDIN")
-	inPlace  = flag.Bool("in-place", false, "write output back to the file specified by -f")
-	posix    = flag.BoolP("posix", "p", false, "preprocess with POSIX variable expansion")
-	version  = flag.BoolP("version", "v", false, "prints version")
+	filename  = flag.StringP("filename", "f", "", "use template file instead of STDIN")
+	inline    = flag.StringP("inline", "i", "", "use inline template string instead of STDIN")
+	inPlace   = flag.Bool("in-place", false, "write output back to the file specified by -f")
+	varsFiles = flag.StringArrayP("vars-file", "V", []string{}, "load variables from a file (JSON, YAML, or env format)")
+	posix     = flag.BoolP("posix", "p", false, "preprocess with POSIX variable expansion")
+	version   = flag.BoolP("version", "v", false, "prints version")
 )
 
 func template() ([]byte, string, error) {
@@ -101,6 +102,16 @@ func main() {
 	}
 
 	vars := make(map[string]interface{})
+	for _, vf := range *varsFiles {
+		fileVars, err := sigil.ParseVarsFile(vf)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		for k, v := range fileVars {
+			vars[k] = v
+		}
+	}
 	for _, arg := range flag.Args() {
 		parts := strings.SplitN(arg, "=", 2)
 		if len(parts) == 2 {

--- a/go.mod
+++ b/go.mod
@@ -11,4 +11,7 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 )
 
-require github.com/dustin/gojson v0.0.0-20160307161227-2e71ec9dd5ad // indirect
+require (
+	github.com/dustin/gojson v0.0.0-20160307161227-2e71ec9dd5ad // indirect
+	github.com/joho/godotenv v1.5.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9Y
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/mgood/go-posix v0.0.0-20150821180505-948c005421f5 h1:AutzcJSqc7ROMqcjPKmxwLl//YrzDPb4tLSBlH3Irdc=
 github.com/mgood/go-posix v0.0.0-20150821180505-948c005421f5/go.mod h1:irVTeKOI2GrudEK6/mqR4dDlGH91lCZIZM34YKSKH7M=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/sigil.go
+++ b/sigil.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/joho/godotenv"
 	"github.com/mgood/go-posix"
 	"gopkg.in/yaml.v2"
 )
@@ -117,27 +118,13 @@ func convertYAMLMap(m map[interface{}]interface{}) map[string]interface{} {
 }
 
 func parseEnvContent(data []byte) (map[string]interface{}, error) {
-	vars := make(map[string]interface{})
-	lines := strings.Split(string(data), "\n")
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
-		}
-		line = strings.TrimPrefix(line, "export ")
-		parts := strings.SplitN(line, "=", 2)
-		if len(parts) != 2 {
-			continue
-		}
-		key := strings.TrimSpace(parts[0])
-		value := strings.TrimSpace(parts[1])
-		if len(value) >= 2 {
-			if (value[0] == '"' && value[len(value)-1] == '"') ||
-				(value[0] == '\'' && value[len(value)-1] == '\'') {
-				value = value[1 : len(value)-1]
-			}
-		}
-		vars[key] = value
+	parsed, err := godotenv.Parse(bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+	vars := make(map[string]interface{}, len(parsed))
+	for k, v := range parsed {
+		vars[k] = v
 	}
 	return vars, nil
 }

--- a/sigil.go
+++ b/sigil.go
@@ -2,6 +2,7 @@ package sigil
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -10,6 +11,7 @@ import (
 	"text/template"
 
 	"github.com/mgood/go-posix"
+	"gopkg.in/yaml.v2"
 )
 
 var (
@@ -90,6 +92,90 @@ func fileExists(path string) bool {
 		return false
 	}
 	return true
+}
+
+func convertYAMLValue(v interface{}) interface{} {
+	switch t := v.(type) {
+	case map[interface{}]interface{}:
+		return convertYAMLMap(t)
+	case []interface{}:
+		for i, elem := range t {
+			t[i] = convertYAMLValue(elem)
+		}
+		return t
+	default:
+		return v
+	}
+}
+
+func convertYAMLMap(m map[interface{}]interface{}) map[string]interface{} {
+	result := make(map[string]interface{})
+	for k, v := range m {
+		result[fmt.Sprintf("%v", k)] = convertYAMLValue(v)
+	}
+	return result
+}
+
+func parseEnvContent(data []byte) (map[string]interface{}, error) {
+	vars := make(map[string]interface{})
+	lines := strings.Split(string(data), "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		line = strings.TrimPrefix(line, "export ")
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key := strings.TrimSpace(parts[0])
+		value := strings.TrimSpace(parts[1])
+		if len(value) >= 2 {
+			if (value[0] == '"' && value[len(value)-1] == '"') ||
+				(value[0] == '\'' && value[len(value)-1] == '\'') {
+				value = value[1 : len(value)-1]
+			}
+		}
+		vars[key] = value
+	}
+	return vars, nil
+}
+
+// ParseVarsFile reads a file and parses it as template variables.
+// The format is auto-detected by file extension:
+// .json files are parsed as JSON objects, .yaml/.yml as YAML mappings,
+// and all other extensions as key=value lines.
+func ParseVarsFile(path string) (map[string]interface{}, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read vars file %s: %w", path, err)
+	}
+
+	ext := strings.ToLower(filepath.Ext(path))
+	switch ext {
+	case ".json":
+		var obj map[string]interface{}
+		if err := json.Unmarshal(data, &obj); err != nil {
+			return nil, fmt.Errorf("failed to parse JSON vars file %s: %w", path, err)
+		}
+		return obj, nil
+	case ".yaml", ".yml":
+		var obj interface{}
+		if err := yaml.Unmarshal(data, &obj); err != nil {
+			return nil, fmt.Errorf("failed to parse YAML vars file %s: %w", path, err)
+		}
+		if obj == nil {
+			return make(map[string]interface{}), nil
+		}
+		m, ok := obj.(map[interface{}]interface{})
+		if !ok {
+			return nil, fmt.Errorf("YAML vars file %s must contain a mapping at top level", path)
+		}
+		return convertYAMLMap(m), nil
+	default:
+		return parseEnvContent(data)
+	}
 }
 
 func restoreEnv(env []string) {

--- a/sigil_test.go
+++ b/sigil_test.go
@@ -3,6 +3,7 @@ package sigil
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 )
 
@@ -46,5 +47,263 @@ func TestLookPath(t *testing.T) {
 				os.Remove(f.Name())
 			}
 		}
+	}
+}
+
+func writeTempFile(t *testing.T, ext, content string) string {
+	t.Helper()
+	f, err := os.CreateTemp("", "sigil-test-*"+ext)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString(content); err != nil {
+		f.Close()
+		os.Remove(f.Name())
+		t.Fatal(err)
+	}
+	f.Close()
+	return f.Name()
+}
+
+func TestParseVarsFileJSON(t *testing.T) {
+	path := writeTempFile(t, ".json", `{"name": "Jeff", "greeting": "Hello"}`)
+	defer os.Remove(path)
+
+	vars, err := ParseVarsFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if vars["name"] != "Jeff" {
+		t.Errorf("expected name=Jeff, got %v", vars["name"])
+	}
+	if vars["greeting"] != "Hello" {
+		t.Errorf("expected greeting=Hello, got %v", vars["greeting"])
+	}
+}
+
+func TestParseVarsFileJSONNested(t *testing.T) {
+	path := writeTempFile(t, ".json", `{"db": {"host": "localhost", "port": 5432}}`)
+	defer os.Remove(path)
+
+	vars, err := ParseVarsFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	db, ok := vars["db"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected db to be map, got %T", vars["db"])
+	}
+	if db["host"] != "localhost" {
+		t.Errorf("expected db.host=localhost, got %v", db["host"])
+	}
+}
+
+func TestParseVarsFileYAML(t *testing.T) {
+	path := writeTempFile(t, ".yaml", "name: Jeff\ngreeting: Hello\n")
+	defer os.Remove(path)
+
+	vars, err := ParseVarsFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if vars["name"] != "Jeff" {
+		t.Errorf("expected name=Jeff, got %v", vars["name"])
+	}
+	if vars["greeting"] != "Hello" {
+		t.Errorf("expected greeting=Hello, got %v", vars["greeting"])
+	}
+}
+
+func TestParseVarsFileYML(t *testing.T) {
+	path := writeTempFile(t, ".yml", "name: Jeff\n")
+	defer os.Remove(path)
+
+	vars, err := ParseVarsFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if vars["name"] != "Jeff" {
+		t.Errorf("expected name=Jeff, got %v", vars["name"])
+	}
+}
+
+func TestParseVarsFileYAMLNested(t *testing.T) {
+	path := writeTempFile(t, ".yaml", "db:\n  host: localhost\n  port: 5432\n")
+	defer os.Remove(path)
+
+	vars, err := ParseVarsFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	db, ok := vars["db"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected db to be map, got %T", vars["db"])
+	}
+	if db["host"] != "localhost" {
+		t.Errorf("expected db.host=localhost, got %v", db["host"])
+	}
+}
+
+func TestParseVarsFileEnv(t *testing.T) {
+	content := "# comment\nname=Jeff\ngreeting=\"Hello World\"\n\nexport FOO='bar'\n"
+	path := writeTempFile(t, ".env", content)
+	defer os.Remove(path)
+
+	vars, err := ParseVarsFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if vars["name"] != "Jeff" {
+		t.Errorf("expected name=Jeff, got %v", vars["name"])
+	}
+	if vars["greeting"] != "Hello World" {
+		t.Errorf("expected greeting='Hello World', got %v", vars["greeting"])
+	}
+	if vars["FOO"] != "bar" {
+		t.Errorf("expected FOO=bar, got %v", vars["FOO"])
+	}
+}
+
+func TestParseVarsFileEnvValueWithEquals(t *testing.T) {
+	path := writeTempFile(t, ".env", "connection=host=localhost dbname=test\n")
+	defer os.Remove(path)
+
+	vars, err := ParseVarsFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if vars["connection"] != "host=localhost dbname=test" {
+		t.Errorf("expected value with equals preserved, got %v", vars["connection"])
+	}
+}
+
+func TestParseVarsFileEnvEmptyValue(t *testing.T) {
+	path := writeTempFile(t, ".env", "empty=\n")
+	defer os.Remove(path)
+
+	vars, err := ParseVarsFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if vars["empty"] != "" {
+		t.Errorf("expected empty value, got %v", vars["empty"])
+	}
+}
+
+func TestParseVarsFileUnknownExtension(t *testing.T) {
+	path := writeTempFile(t, ".txt", "name=Jeff\ncolor=red\n")
+	defer os.Remove(path)
+
+	vars, err := ParseVarsFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if vars["name"] != "Jeff" {
+		t.Errorf("expected name=Jeff, got %v", vars["name"])
+	}
+	if vars["color"] != "red" {
+		t.Errorf("expected color=red, got %v", vars["color"])
+	}
+}
+
+func TestParseVarsFileNotFound(t *testing.T) {
+	_, err := ParseVarsFile("/nonexistent/file.json")
+	if err == nil {
+		t.Error("expected error for missing file")
+	}
+}
+
+func TestParseVarsFileInvalidJSON(t *testing.T) {
+	path := writeTempFile(t, ".json", "not json")
+	defer os.Remove(path)
+
+	_, err := ParseVarsFile(path)
+	if err == nil {
+		t.Error("expected error for invalid JSON")
+	}
+}
+
+func TestParseVarsFileInvalidYAML(t *testing.T) {
+	path := writeTempFile(t, ".yaml", "- one\n- two\n")
+	defer os.Remove(path)
+
+	_, err := ParseVarsFile(path)
+	if err == nil {
+		t.Error("expected error for YAML list at top level")
+	}
+}
+
+func TestParseVarsFileEmptyYAML(t *testing.T) {
+	path := writeTempFile(t, ".yaml", "")
+	defer os.Remove(path)
+
+	vars, err := ParseVarsFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(vars) != 0 {
+		t.Errorf("expected empty map, got %v", vars)
+	}
+}
+
+func TestParseEnvContentExportWithoutSpace(t *testing.T) {
+	vars, err := parseEnvContent([]byte("exportFOO=bar\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if vars["exportFOO"] != "bar" {
+		t.Errorf("expected exportFOO=bar, got %v", vars)
+	}
+}
+
+func TestParseEnvContentSkipsNoEquals(t *testing.T) {
+	vars, err := parseEnvContent([]byte("noequals\nname=Jeff\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(vars) != 1 {
+		t.Errorf("expected 1 var, got %d", len(vars))
+	}
+	if vars["name"] != "Jeff" {
+		t.Errorf("expected name=Jeff, got %v", vars["name"])
+	}
+}
+
+func TestConvertYAMLMap(t *testing.T) {
+	input := map[interface{}]interface{}{
+		"name": "Jeff",
+		"nested": map[interface{}]interface{}{
+			"key": "value",
+		},
+	}
+	result := convertYAMLMap(input)
+	if result["name"] != "Jeff" {
+		t.Errorf("expected name=Jeff, got %v", result["name"])
+	}
+	nested, ok := result["nested"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected nested to be map[string]interface{}, got %T", result["nested"])
+	}
+	if nested["key"] != "value" {
+		t.Errorf("expected nested.key=value, got %v", nested["key"])
+	}
+}
+
+func TestConvertYAMLValueSlice(t *testing.T) {
+	input := []interface{}{
+		map[interface{}]interface{}{"a": "b"},
+		"plain",
+	}
+	result := convertYAMLValue(input)
+	slice, ok := result.([]interface{})
+	if !ok {
+		t.Fatalf("expected slice, got %T", result)
+	}
+	m, ok := slice[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map in slice, got %T", slice[0])
+	}
+	if !reflect.DeepEqual(m, map[string]interface{}{"a": "b"}) {
+		t.Errorf("unexpected map: %v", m)
 	}
 }

--- a/sigil_test.go
+++ b/sigil_test.go
@@ -256,16 +256,10 @@ func TestParseEnvContentExportWithoutSpace(t *testing.T) {
 	}
 }
 
-func TestParseEnvContentSkipsNoEquals(t *testing.T) {
-	vars, err := parseEnvContent([]byte("noequals\nname=Jeff\n"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(vars) != 1 {
-		t.Errorf("expected 1 var, got %d", len(vars))
-	}
-	if vars["name"] != "Jeff" {
-		t.Errorf("expected name=Jeff, got %v", vars["name"])
+func TestParseEnvContentRejectsNoEquals(t *testing.T) {
+	_, err := parseEnvContent([]byte("noequals\nname=Jeff\n"))
+	if err == nil {
+		t.Error("expected error for line without =")
 	}
 }
 

--- a/tests/sigil.bats
+++ b/tests/sigil.bats
@@ -229,3 +229,125 @@ EOF
   rm -f "$tmpfile"
   [[ "$result" == "Hello, World" ]]
 }
+
+@test "vars-file with JSON file" {
+  tmpfile=$(mktemp)
+  mv "$tmpfile" "${tmpfile}.json"
+  tmpfile="${tmpfile}.json"
+  echo '{"name": "Jeff"}' >"$tmpfile"
+  result=$(echo 'Hello, {{ $name }}' | $SIGIL -V "$tmpfile")
+  rm -f "$tmpfile"
+  [[ "$result" == "Hello, Jeff" ]]
+}
+
+@test "vars-file with YAML file" {
+  tmpfile=$(mktemp)
+  mv "$tmpfile" "${tmpfile}.yaml"
+  tmpfile="${tmpfile}.yaml"
+  echo 'name: Jeff' >"$tmpfile"
+  result=$(echo 'Hello, {{ $name }}' | $SIGIL -V "$tmpfile")
+  rm -f "$tmpfile"
+  [[ "$result" == "Hello, Jeff" ]]
+}
+
+@test "vars-file with .yml extension" {
+  tmpfile=$(mktemp)
+  mv "$tmpfile" "${tmpfile}.yml"
+  tmpfile="${tmpfile}.yml"
+  echo 'name: Jeff' >"$tmpfile"
+  result=$(echo 'Hello, {{ $name }}' | $SIGIL --vars-file "$tmpfile")
+  rm -f "$tmpfile"
+  [[ "$result" == "Hello, Jeff" ]]
+}
+
+@test "vars-file with env file" {
+  tmpfile=$(mktemp)
+  mv "$tmpfile" "${tmpfile}.env"
+  tmpfile="${tmpfile}.env"
+  printf '# a comment\nname=Jeff\n' >"$tmpfile"
+  result=$(echo 'Hello, {{ $name }}' | $SIGIL -V "$tmpfile")
+  rm -f "$tmpfile"
+  [[ "$result" == "Hello, Jeff" ]]
+}
+
+@test "vars-file with env file and quoted values" {
+  tmpfile=$(mktemp)
+  mv "$tmpfile" "${tmpfile}.env"
+  tmpfile="${tmpfile}.env"
+  printf 'name="Jeff Doe"\n' >"$tmpfile"
+  result=$(echo 'Hello, {{ $name }}' | $SIGIL -V "$tmpfile")
+  rm -f "$tmpfile"
+  [[ "$result" == "Hello, Jeff Doe" ]]
+}
+
+@test "vars-file with env file and export prefix" {
+  tmpfile=$(mktemp)
+  mv "$tmpfile" "${tmpfile}.env"
+  tmpfile="${tmpfile}.env"
+  printf 'export name=Jeff\n' >"$tmpfile"
+  result=$(echo 'Hello, {{ $name }}' | $SIGIL -V "$tmpfile")
+  rm -f "$tmpfile"
+  [[ "$result" == "Hello, Jeff" ]]
+}
+
+@test "vars-file CLI args override file vars" {
+  tmpfile=$(mktemp)
+  mv "$tmpfile" "${tmpfile}.json"
+  tmpfile="${tmpfile}.json"
+  echo '{"name": "FileJeff"}' >"$tmpfile"
+  result=$(echo 'Hello, {{ $name }}' | $SIGIL -V "$tmpfile" name=CLIJeff)
+  rm -f "$tmpfile"
+  [[ "$result" == "Hello, CLIJeff" ]]
+}
+
+@test "vars-file multiple files merge in order" {
+  tmpfile1=$(mktemp)
+  mv "$tmpfile1" "${tmpfile1}.json"
+  tmpfile1="${tmpfile1}.json"
+  tmpfile2=$(mktemp)
+  mv "$tmpfile2" "${tmpfile2}.json"
+  tmpfile2="${tmpfile2}.json"
+  echo '{"name": "First", "color": "red"}' >"$tmpfile1"
+  echo '{"name": "Second"}' >"$tmpfile2"
+  result=$(echo '{{ $name }},{{ $color }}' | $SIGIL -V "$tmpfile1" -V "$tmpfile2")
+  rm -f "$tmpfile1" "$tmpfile2"
+  [[ "$result" == "Second,red" ]]
+}
+
+@test "vars-file with POSIX mode" {
+  tmpfile=$(mktemp)
+  mv "$tmpfile" "${tmpfile}.json"
+  tmpfile="${tmpfile}.json"
+  echo '{"name": "Jeff"}' >"$tmpfile"
+  result=$(echo 'Hello, $name' | $SIGIL -p -V "$tmpfile")
+  rm -f "$tmpfile"
+  [[ "$result" == "Hello, Jeff" ]]
+}
+
+@test "vars-file nonexistent file fails" {
+  run $SIGIL -i 'Hello' -V /nonexistent/vars.json
+  [[ "$status" -ne 0 ]]
+}
+
+@test "vars-file invalid JSON fails" {
+  tmpfile=$(mktemp)
+  mv "$tmpfile" "${tmpfile}.json"
+  tmpfile="${tmpfile}.json"
+  echo 'not json' >"$tmpfile"
+  run $SIGIL -i 'Hello' -V "$tmpfile"
+  rm -f "$tmpfile"
+  [[ "$status" -ne 0 ]]
+}
+
+@test "vars-file with in-place mode" {
+  varsfile=$(mktemp)
+  mv "$varsfile" "${varsfile}.json"
+  varsfile="${varsfile}.json"
+  tmplfile=$(mktemp)
+  echo '{"name": "Jeff"}' >"$varsfile"
+  echo 'Hello, {{ $name }}' >"$tmplfile"
+  $SIGIL --in-place -f "$tmplfile" -V "$varsfile"
+  result=$(cat "$tmplfile")
+  rm -f "$varsfile" "$tmplfile"
+  [[ "$result" == "Hello, Jeff" ]]
+}


### PR DESCRIPTION
## Summary

- Adds a `-V`/`--vars-file` CLI flag to load template variables from JSON, YAML, or env/key=value files
- File format is auto-detected by extension (`.json`, `.yaml`/`.yml`, or env-style for all others)
- The flag can be specified multiple times; files merge in order with CLI `key=value` args taking precedence
- Env-style format supports `#` comments, empty lines, `export` prefix, and quoted values

Closes #40