### PR TITLE
fix: auto-declare missing template variables to support default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ for functions available:
 Here are a few examples:
 
 * `{{ $variable | capitalize }}`
+* `{{ $variable | default "fallback" }}` - use fallback when variable is not provided or empty
 * `{{ include "file.tmpl" "var1=foo" "var2=bar" }}`
 * `{{ file "example.txt" | replace "old" "new" }}`
 * `{{ json "file.json" | pointer "/Widgets/0/Name" }}`

--- a/sigil.go
+++ b/sigil.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"text/template"
 
@@ -173,10 +174,20 @@ func restoreEnv(env []string) {
 	}
 }
 
+var templateVarRe = regexp.MustCompile(`\$([a-zA-Z_][a-zA-Z0-9_]*)`)
+
 func Execute(input []byte, vars map[string]interface{}, name string) (bytes.Buffer, error) {
 	var tmplVars string
 	var err error
 	defer restoreEnv(os.Environ())
+	// Scan template for $variable references and declare missing ones as nil.
+	// This allows patterns like {{ $x | default "foo" }} to work when x is not provided.
+	for _, match := range templateVarRe.FindAllSubmatch(input, -1) {
+		varName := string(match[1])
+		if _, exists := vars[varName]; !exists {
+			vars[varName] = nil
+		}
+	}
 	for k, iv := range vars {
 		if v, ok := iv.(string); ok {
 			err := os.Setenv(k, v)

--- a/sigil_test.go
+++ b/sigil_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
+	"text/template"
 )
 
 func TestLookPath(t *testing.T) {
@@ -280,6 +281,80 @@ func TestConvertYAMLMap(t *testing.T) {
 	}
 	if nested["key"] != "value" {
 		t.Errorf("expected nested.key=value, got %v", nested["key"])
+	}
+}
+
+func registerDefaultFunc() {
+	Register(template.FuncMap{
+		"default": func(value, in interface{}) interface{} {
+			if in == nil {
+				return value
+			}
+			if reflect.Zero(reflect.TypeOf(in)).Interface() == in {
+				return value
+			}
+			return in
+		},
+	})
+}
+
+func TestExecuteDefaultWithMissingVariable(t *testing.T) {
+	registerDefaultFunc()
+	vars := map[string]interface{}{}
+	buf, err := Execute([]byte(`{{ $x | default "foo" }}`), vars, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if buf.String() != "foo" {
+		t.Errorf("expected 'foo', got %q", buf.String())
+	}
+}
+
+func TestExecuteDefaultWithEmptyVariable(t *testing.T) {
+	registerDefaultFunc()
+	vars := map[string]interface{}{"x": ""}
+	buf, err := Execute([]byte(`{{ $x | default "foo" }}`), vars, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if buf.String() != "foo" {
+		t.Errorf("expected 'foo', got %q", buf.String())
+	}
+}
+
+func TestExecuteDefaultWithProvidedVariable(t *testing.T) {
+	registerDefaultFunc()
+	vars := map[string]interface{}{"x": "bar"}
+	buf, err := Execute([]byte(`{{ $x | default "foo" }}`), vars, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if buf.String() != "bar" {
+		t.Errorf("expected 'bar', got %q", buf.String())
+	}
+}
+
+func TestExecuteMultipleMissingVariablesWithDefaults(t *testing.T) {
+	registerDefaultFunc()
+	vars := map[string]interface{}{}
+	buf, err := Execute([]byte(`{{ $a | default "A" }}-{{ $b | default "B" }}`), vars, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if buf.String() != "A-B" {
+		t.Errorf("expected 'A-B', got %q", buf.String())
+	}
+}
+
+func TestExecuteMixedProvidedAndMissingDefaults(t *testing.T) {
+	registerDefaultFunc()
+	vars := map[string]interface{}{"a": "hello"}
+	buf, err := Execute([]byte(`{{ $a | default "A" }}-{{ $b | default "B" }}`), vars, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if buf.String() != "hello-B" {
+		t.Errorf("expected 'hello-B', got %q", buf.String())
 	}
 }
 

--- a/tests/sigil.bats
+++ b/tests/sigil.bats
@@ -339,6 +339,41 @@ EOF
   [[ "$status" -ne 0 ]]
 }
 
+@test "default with missing variable" {
+  result=$($SIGIL -i '{{ $x | default "fallback" }}')
+  [[ "$result" == "fallback" ]]
+}
+
+@test "default with empty variable" {
+  result=$($SIGIL -i '{{ $x | default "fallback" }}' x=)
+  [[ "$result" == "fallback" ]]
+}
+
+@test "default with provided variable" {
+  result=$($SIGIL -i '{{ $x | default "fallback" }}' x=hello)
+  [[ "$result" == "hello" ]]
+}
+
+@test "default with dot syntax for missing variable" {
+  result=$($SIGIL -i '{{ $.x | default "fallback" }}')
+  [[ "$result" == "fallback" ]]
+}
+
+@test "multiple missing variables with defaults" {
+  result=$($SIGIL -i '{{ $a | default "A" }}-{{ $b | default "B" }}')
+  [[ "$result" == "A-B" ]]
+}
+
+@test "default with mixed provided and missing variables" {
+  result=$($SIGIL -i '{{ $a | default "A" }}-{{ $b | default "B" }}' a=hello)
+  [[ "$result" == "hello-B" ]]
+}
+
+@test "range still works with default variable fix" {
+  result=$(echo 'Sigil is{{ range $i := seq 3 }} cool{{ end }}!' | $SIGIL)
+  [[ "$result" == "Sigil is cool cool cool!" ]]
+}
+
 @test "vars-file with in-place mode" {
   varsfile=$(mktemp)
   mv "$varsfile" "${varsfile}.json"


### PR DESCRIPTION
## Summary

- Scans templates for `$variable` references before execution and auto-declares any missing variables as nil, so `{{ $x | default "foo" }}` works when `x` is not provided instead of failing with "undefined variable"
- Documents the `default` function in the README

Closes #55